### PR TITLE
Package collapse on prefix

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,11 +1,14 @@
 [
-    { "keys": ["ctrl+shift+e"], "command": "scoggle", "args": {"matcher": "prefix_suffix_matcher"}, 
+    { "keys": ["ctrl+shift+e"], "command": "scoggle", "args": {"matcher": "prefix_suffix_matcher"},
         "context" : [{"key": "selector", "operator": "equal", "operand": "source.scala", "match_all": true}]},
 
-    { "keys": ["ctrl+shift+ctrl+e"], "command": "scoggle", "args": {"matcher": "prefix_wildcard_suffix_matcher"}, 
+    { "keys": ["ctrl+shift+ctrl+e"], "command": "scoggle", "args": {"matcher": "prefix_wildcard_suffix_matcher"},
     "context" : [{"key": "selector", "operator": "equal", "operand": "source.scala", "match_all": true}]},
 
-    { "keys": ["ctrl+shift+ctrl+x"], "command": "scoggle", "args": {"matcher": "wildcard_prefix_wildcard_suffix_matcher"}, 
+    { "keys": ["ctrl+shift+ctrl+x"], "command": "scoggle", "args": {"matcher": "wildcard_prefix_wildcard_suffix_matcher"},
     "context" : [{"key": "selector", "operator": "equal", "operand": "source.scala", "match_all": true}]},
-    
+
+    { "keys": ["ctrl+shift+g"], "command": "package", "args" : {"style" : "full"} },
+
+    { "keys": ["ctrl+shift+h"], "command": "package", "args" : {"style" : "step"} }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -8,6 +8,8 @@
     { "keys": ["super+shift+ctrl+x"], "command": "scoggle", "args": {"matcher": "wildcard_prefix_wildcard_suffix_matcher"},
     "context" : [{"key": "selector", "operator": "equal", "operand": "source.scala", "match_all": true}]},
 
-    { "keys": ["super+shift+g"], "command": "package" }
+    { "keys": ["super+shift+g"], "command": "package", "args" : {"style" : "full"} },
+
+    { "keys": ["super+shift+h"], "command": "package", "args" : {"style" : "step"} }
 
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -2,5 +2,6 @@
     { "caption": "Scoggle: Toggle exact", "command": "scoggle", "args": {"matcher": "prefix_suffix_matcher"} },
     { "caption": "Scoggle: Toggle wildcard", "command": "scoggle", "args": {"matcher": "prefix_wildcard_suffix_matcher"}},
     { "caption": "Scoggle: Toggle fuzzy", "command": "scoggle", "args": {"matcher": "wildcard_prefix_wildcard_suffix_matcher"} },
-    { "caption": "Scoggle: Insert package", "command": "package" }
+    { "caption": "Scoggle: Insert package", "command": "package", "args": {"style": "full"} },
+    { "caption": "Scoggle: Insert package Steps", "command": "package", "args": {"style": "step"} }
 ]

--- a/components/scoggle.py
+++ b/components/scoggle.py
@@ -38,6 +38,14 @@ class Scoggle:
 
         raise sypes.CantDeterminePackageError(current_file, paths)
 
+    def already_has_package(self, content):
+        if (content is None):
+            return False
+        else:
+            newline = "\n"
+            lines = content.split(newline)
+            return len(lines) > 0 and lines[0].startswith("package")
+
     def get_updated_package_text(self, content, dotted):
         """
             content - the content of the source file.
@@ -62,7 +70,7 @@ class Scoggle:
         #os.linesep works for linux and mac but not windows.
         #Hard-coding to '\n' as it seems to work across all operation systems.
         newline = '\n'
-        defaultContent = newline.join([("package " + dotted), "", ""])
+        defaultContent = newline.join([dotted, "", ""])
         if (content is None):
             return defaultContent
 
@@ -76,12 +84,12 @@ class Scoggle:
         elif (not(lines[0].startswith("package"))):
             if (len(lines[0]) == 0 and len(lines[1]) == 0):
                 #the first line is a newline
-                return newline.join([("package " + dotted)] + lines[1:])
+                return newline.join([dotted] + lines[1:])
             elif (len(lines[0]) == 0 and len(lines[1]) != 0):
-                return newline.join([("package " + dotted)] + lines)
+                return newline.join([dotted] + lines)
             else:
                 #the first line is not a newline
-                return newline.join([("package " + dotted), ""] + lines)
+                return newline.join([dotted, ""] + lines)
         else:
             #already has a package
             return newline.join(lines)
@@ -177,6 +185,19 @@ class Scoggle:
 
     def display_error_in(self, message, location):
         location.display_message(message)
+
+    def get_package_steps(self, full, sub):
+        if (not(sub.endswith("."))):
+            sub  += "."
+
+        if (full.startswith(sub)):
+            other = full.replace(sub, "")
+            parts = [sub[:-1]] + other.split(".")
+            newline = "\n"
+            return newline.join(list(map(lambda p: "package " + p, parts)))
+        else:
+            # the sub package requested is not a valid prefix of the full package.
+            return None
 
     @staticmethod
     def is_visible(view, version):

--- a/components/sublime_wrapper.py
+++ b/components/sublime_wrapper.py
@@ -14,7 +14,13 @@ class SublimeWrapper:
         location.display_message(message)
 
     def show_status_message(self, message):
-        sublime.status_message(message)    
+        sublime.status_message(message)
+
+    def getActiveWindow(self):
+        return sublime.active_window()
+
+    def show_input_panel(self, caption, text, on_done, on_change, on_cancel):
+        sublime.active_window().show_input_panel(caption, text, on_done, on_change, on_cancel)
 
     def show_results_list_with_location(self, matches, display_location):
         if (len(matches) == 0):

--- a/tests/scoggle_test.py
+++ b/tests/scoggle_test.py
@@ -131,6 +131,31 @@ class ScoggleTest(unittest.TestCase):
     expected = dotted + content
     self.assertEqual(self.cut.get_updated_package_text(content, dotted), expected)
 
+  #already_has_package
+  def test_already_has_package_without_package_line(self):
+    self.assertEqual(self.cut.already_has_package(None), False)
+    self.assertEqual(self.cut.already_has_package(""), False)
+    self.assertEqual(self.cut.already_has_package("line without newline"), False)
+
+  def test_already_has_package_with_package_line(self):
+    self.assertEqual(self.cut.already_has_package("package blah.de.blee"), True)
+    self.assertEqual(self.cut.already_has_package("package blah.de.blah\n"), True)
+    self.assertEqual(self.cut.already_has_package("package net.ssanj.test\n\nimport scala.util.Random"), True)
+
+  #get_package_steps
+  def test_get_package_steps_with_sub_package(self):
+      full = "net.ssanj.dabble.dsl.property"
+      sub  = "net.ssanj.dabble"
+      self.assertEqual(self.cut.get_package_steps(full, sub), "package net.ssanj.dabble\npackage dsl\npackage property")
+
+  def test_get_package_steps_with_sub_package_ending_with_dot(self):
+      full = "net.ssanj.dabble.dsl.property"
+      sub  = "net.ssanj.dabble."
+      self.assertEqual(self.cut.get_package_steps(full, sub), "package net.ssanj.dabble\npackage dsl\npackage property")
+
+  def test_get_package_steps_without_sub_package(self):
+      self.assertEqual(self.cut.get_package_steps("net.ssanj.dabble", "dabble.ssanj.net"), None)
+      self.assertEqual(self.cut.get_package_steps("net.ssanj.dabble", "net.ssanj.dabble"), None)
 
   # prepend_prefix_to_suffixes
 

--- a/tests/scoggle_test.py
+++ b/tests/scoggle_test.py
@@ -87,52 +87,48 @@ class ScoggleTest(unittest.TestCase):
   # get_updated_package_text
 
   def test_get_updated_package_text_new_file(self):
-    newline = os.linesep
-    expected = "package one.two.three" + newline + newline
+    newline  = os.linesep
+    expected = "one.two.three" + newline + newline
     self.assertEqual(self.cut.get_updated_package_text("", "one.two.three"), expected)
     self.assertEqual(self.cut.get_updated_package_text(None, "one.two.three"), expected)
 
   def test_get_updated_package_text_file_with_newline_only(self):
     newline = os.linesep
-    self.assertEqual(self.cut.get_updated_package_text(newline, "one.two.three"), "package one.two.three" + newline + newline)
+    self.assertEqual(self.cut.get_updated_package_text(newline, "one.two.three"), "one.two.three" + newline + newline)
 
   def test_get_updated_package_text_existing_file_without_package(self):
-    newline = os.linesep
-    dotted = "one.two.three"
-    content = "import scala.concurrent.Future"
-    package = "package " + dotted
-    expected = package + newline + newline + content
+    newline  = os.linesep
+    dotted   = "one.two.three"
+    content  = "import scala.concurrent.Future"
+    expected = dotted + newline + newline + content
     self.assertEqual(self.cut.get_updated_package_text(content, dotted), expected)
 
   def test_get_updated_package_text_existing_file_without_package_with_empty_first_line(self):
-    newline = os.linesep
-    dotted = "one.two.three"
-    content = newline + "import scala.concurrent.Future"
-    package = "package " + dotted
-    expected = package + newline + content
+    newline  = os.linesep
+    dotted   = "one.two.three"
+    content  = newline + "import scala.concurrent.Future"
+    expected = dotted + newline + content
     self.assertEqual(self.cut.get_updated_package_text(content, dotted), expected)
 
   def test_get_updated_package_text_existing_file_without_package_with_empty_first_two_lines(self):
     newline = os.linesep
     dotted = "one.two.three"
     content = newline + newline
-    package = "package " + dotted
-    expected = package + content
+    expected = dotted + content
     self.assertEqual(self.cut.get_updated_package_text(content, dotted), expected)
 
   def test_get_updated_package_text_existing_file_with_package(self):
-    newline = os.linesep
-    dotted = "one.two.three"
-    content = "package " + dotted + newline + "import scala.concurrent.ExecutionContext"
+    newline  = os.linesep
+    dotted   = "one.two.three"
+    content  = "package " + dotted + newline + "import scala.concurrent.ExecutionContext"
     expected = content
     self.assertEqual(self.cut.get_updated_package_text(content, dotted), expected)
 
   def test_get_updated_package_text_existing_file_without_package_and_two_empty_lines(self):
-    newline = os.linesep
-    dotted = "one.two.three"
-    package = "package " + dotted
-    content = newline + newline + "import scala.concurrent.ExecutionContext"
-    expected = package + content
+    newline  = os.linesep
+    dotted   = "one.two.three"
+    content  = newline + newline + "import scala.concurrent.ExecutionContext"
+    expected = dotted + content
     self.assertEqual(self.cut.get_updated_package_text(content, dotted), expected)
 
 


### PR DESCRIPTION
Add functionality to split a package into sub packages on a given prefix.

Given:

`package com.example.project.domain`

If you split on **com.example**, you get:

```
package com.example
package project
package domain
```
